### PR TITLE
Update update_one() syntax for PyMongo4

### DIFF
--- a/lib/applydb.py
+++ b/lib/applydb.py
@@ -85,7 +85,7 @@ def obtain_submission(username):
     return submission 
 
 def update_submission(submission, update):
-    db.apply.submissions.update({"username": submission["username"]}, {"$set": update})
+    db.apply.submissions.update_one({"username": submission["username"]}, {"$set": update})
 
 def rate_submission(submission, user, rating):
     submission["ratings"][user] = rating


### PR DESCRIPTION
One more! See https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-update-is-removed

Now it is confirmed to be running smoothly locally in a Pytnon 3.11.1 virtualenv with latest versions of Mongo and everything.